### PR TITLE
Allow for case where imzML path has '.' 

### DIFF
--- a/src/imzML.jl
+++ b/src/imzML.jl
@@ -23,8 +23,9 @@ size( spectra )
 function LoadImzml( fileName )
 
   # Open file handles
-  fileName = split( fileName, "." )[1]
-  stream   = open( fileName * ".imzML" )
+  fileName = isfile(fileName) ?
+        splitext( fileName, "." )[1] : error("provided path is not a file")
+  stream   = open( fileName * ".imzML" ) 
   hIbd     = open( fileName * ".ibd" )
 
   # Get axes types and image dimensions


### PR DESCRIPTION
E.g. example 2 from
https://www.ms-imaging.org/imzml/example-files-test/ extracts to data
to the paths "S043_Processed_imzML1.1.1/S043_Processed.{imzML,ibd}". Extracting the directory file paths with `split( fileName, "." )[1]` treats the base directory as the base name of the file ("S043_Processed_imzML.imzML")