### PR TITLE
The prototype's incorrect value definition prevented modification of …

### DIFF
--- a/src/Bitmap.jl
+++ b/src/Bitmap.jl
@@ -317,7 +317,7 @@ The following image will be created on your hard disk
 
 ![](./TrIQ.bmp)
 """
-function TrIQ( slice, depth, prob = 0.98 )
+function TrIQ( slice, depth, prob )
 
   return  SetPixelDepth(
     slice,


### PR DESCRIPTION
…the cut-off probability within the 'TrIQ' function.